### PR TITLE
fix: update alt text and rename routes to use PATCH method

### DIFF
--- a/resources/views/media/index.blade.php
+++ b/resources/views/media/index.blade.php
@@ -1872,15 +1872,33 @@ $authUserId = auth()->id();
     }
 
     // ── Alt text ──────────────────────────────────────────────────────
-    let altTimer;
+    const altTimers = {};
+    const altSaved  = {};
     function saveAlt(id, value) {
-        clearTimeout(altTimer);
-        altTimer = setTimeout(async () => {
-            const fd = new FormData();
-            fd.append('_token', CSRF);
-            fd.append('_method', 'PATCH');
-            fd.append('alt_text', value);
-            await fetch(ALT_BASE + id + '/alt', { method: 'POST', body: fd });
+        if (altSaved[id] === value) return;
+
+        clearTimeout(altTimers[id]);
+        altTimers[id] = setTimeout(async () => {
+            try {
+                const res = await fetch(ALT_BASE + id + '/alt', {
+                    method: 'PATCH',
+                    body: JSON.stringify({ alt_text: value }),
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': CSRF,
+                        'Accept': 'application/json',
+                    },
+                });
+
+                if (!res.ok) {
+                    showAlert('Could not save the alt text. Please try again.', 'Save Failed', { variant: 'danger', confirmText: 'OK' });
+                    return;
+                }
+
+                altSaved[id] = value;
+            } catch {
+                showAlert('Network error. Please try again.', 'Save Failed', { variant: 'danger', confirmText: 'OK' });
+            }
         }, 600);
     }
 
@@ -1901,13 +1919,17 @@ $authUserId = auth()->id();
         // Re-attach the original extension transparently
         const newName = ext ? newDisplay + '.' + ext : newDisplay;
 
-        const fd = new FormData();
-        fd.append('_token', CSRF);
-        fd.append('_method', 'PATCH');
-        fd.append('filename', newName);
-
         try {
-            const res  = await fetch(RENAME_BASE + id + '/rename', { method: 'POST', body: fd, headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+            const res  = await fetch(RENAME_BASE + id + '/rename', {
+                method: 'PATCH',
+                body: JSON.stringify({ filename: newName }),
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': CSRF,
+                    'Accept': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+            });
             const json = await res.json();
             if (res.ok && json.success) {
                 const savedExt = json.filename.includes('.') ? json.filename.split('.').pop() : '';

--- a/routes/web.php
+++ b/routes/web.php
@@ -89,7 +89,7 @@ Route::prefix('media')->name('media.')->group(function () {
     Route::post('/starred-images', [MediaController::class, 'storeStarredImage'])->name('starred-images.store');
     Route::delete('/starred-images', [MediaController::class, 'destroyStarredImage'])->name('starred-images.destroy');
     Route::delete('/bulk-delete', [MediaController::class, 'bulkDestroy'])->name('bulk-destroy');
-    Route::post('/{media}/alt', [MediaController::class, 'updateAlt'])->name('alt');
+    Route::patch('/{media}/alt', [MediaController::class, 'updateAlt'])->name('alt');
     Route::patch('/{media}/rename', [MediaController::class, 'rename'])->name('rename');
     Route::post('/{media}/crop-resize', [MediaController::class, 'cropResize'])->name('crop-resize');
     Route::delete('/{media}', [MediaController::class, 'destroy'])->name('destroy')->where('media', '[0-9]+');


### PR DESCRIPTION
## Summary

The alt-text field in the media library never saved — every autosave silently
returned a 405 and nothing persisted. This PR fixes that bug and, in the same
pass, removes the underlying inconsistency that caused it by aligning both media
"update" endpoints (alt text and rename) on a single, native-verb pattern.

## The bug

`saveAlt()` in `resources/views/media/index.blade.php` sent `_method=PATCH` in a
`POST` request (Laravel method spoofing). The route, however, was registered
`POST`-only:

```php
Route::post('/{media}/alt', [MediaController::class, 'updateAlt'])->name('alt');
```

Spoofing rewrote the verb to `PATCH` → no matching route → **405**. The `fetch()`
call never checked `res.ok`, so the failure was completely invisible: no error,
no persisted value. The alt route and the spoof were introduced together, so the
endpoint never worked.